### PR TITLE
fix: propagate fifo and fair queue parameters

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -270,10 +270,12 @@ func BuildBatchRequestEntry(messages ...BatchMessage) ([]types.SendMessageBatchR
 
 		id := aws.String(fmt.Sprintf("msg-%d", i))
 		entries[i] = types.SendMessageBatchRequestEntry{
-			DelaySeconds:      req.DelaySeconds,
-			MessageAttributes: req.MessageAttributes,
-			MessageBody:       aws.String(bm.Body),
-			Id:                id,
+			DelaySeconds:           req.DelaySeconds,
+			MessageAttributes:      req.MessageAttributes,
+			MessageGroupId:         req.MessageGroupId,
+			MessageDeduplicationId: req.MessageDeduplicationId,
+			MessageBody:            aws.String(bm.Body),
+			Id:                     id,
 		}
 		id2index[*id] = i
 	}


### PR DESCRIPTION
Batch pubs silently drop `MessageGroupId` and `MessageDeduplicationId`, making fair queues and FIFO queues unusable. This PR propagates those fields.